### PR TITLE
Fix API authorizer bug when one scope as string

### DIFF
--- a/src/my_data/authorizer.py
+++ b/src/my_data/authorizer.py
@@ -369,7 +369,11 @@ class APIScopeAuthorizer(ValidTokenAuthorizer):
                 authorization. Defaults to True.
         """
         super().__init__()
-        self._required_scopes = required_scopes
+        self._required_scopes: list[str] = []
+        if isinstance(required_scopes, str):
+            self._required_scopes = [required_scopes]
+        else:
+            self._required_scopes = required_scopes
         self._allow_short_lived = allow_short_lived
 
     def authorize(self) -> None:

--- a/tests/test_authorizers.py
+++ b/tests/test_authorizers.py
@@ -499,6 +499,34 @@ def test_api_scope_authorizer_long_lived(
 
 
 @pytest.mark.parametrize("api_token", [
+    '2e3n4RSr4I6TnRSwXRpjDYhs9XIYNwhv',
+])
+def test_api_scope_authorizer_long_lived_one_scope(
+        my_data: MyData,
+        api_token: str) -> None:
+    """Test the scope authorizer on long lived tokens with one needed scope.
+
+    Should be successful since the given long lived tokens has the needed
+    scope. We only test with one scope instead of two to make sure that that
+    works too.
+
+    We added this test after we found out that it didn't work when specifying
+    only one scope as string, instead of mulitple scopes as list.
+
+    Args:
+        my_data: a instance to a MyData object.
+        api_token: a API token to test.
+    """
+    authorizer = APITokenAuthorizer(
+        my_data_object=my_data,
+        api_token=api_token,
+        authorizer=APIScopeAuthorizer(
+            required_scopes='users.create'
+        ))
+    authorizer.authorize()
+
+
+@pytest.mark.parametrize("api_token", [
     'aRlIytpyz61JX2TvczLxJZUsRzk578pE',
 ])
 def test_api_scope_authorizer_short_lived_not_allowed(


### PR DESCRIPTION
When only one scope was given to the `APIScopeAuthorizer` class, and it was passed as string, the Authorizer would assume that the string was a iterable and process each letter als scope. This resulted in `AuthorizationFailed` exceptions when authorization was succesfull.

Fixes #133