### PR TITLE
Rename `MyModel` to `Resource` and add time fields

### DIFF
--- a/src/my_data/creators.py
+++ b/src/my_data/creators.py
@@ -6,7 +6,7 @@ in the database. The ResourceManager uses these classes.
 
 from typing import TypeVar
 
-from my_model import MyModel, User, UserRole, UserScopedModel
+from my_model import Resource, User, UserRole, UserScopedResource
 
 from .data_manipulator import DataManipulator
 from .exceptions import (
@@ -15,7 +15,7 @@ from .exceptions import (
     WrongDataManipulatorError,
 )
 
-T = TypeVar('T', bound=MyModel)
+T = TypeVar('T', bound=Resource)
 
 
 class Creator(DataManipulator[T]):
@@ -86,7 +86,7 @@ class UserScopedCreator(Creator[T]):
         Returns:
             True when the user can create these types of objects.
         """
-        if not issubclass(self._database_model, UserScopedModel):
+        if not issubclass(self._database_model, UserScopedResource):
             raise WrongDataManipulatorError(
                 f'The model "{self._database_model}" is not a UserScopedModel'
             )

--- a/src/my_data/data_loader.py
+++ b/src/my_data/data_loader.py
@@ -10,7 +10,7 @@ from my_model import (
     APIScope,
     APIToken,
     APITokenScope,
-    MyModel,
+    Resource,
     Tag,
     User,
     UserSetting,
@@ -52,7 +52,7 @@ class JSONDataSource(DataSource):
         resources_to_add: list[SQLModel] = []
 
         # Dict with userscoped resources as found in the JSON file.
-        user_scoped_resources: dict[str, Type[MyModel]] = {
+        user_scoped_resources: dict[str, Type[Resource]] = {
             '_tags': Tag,
             '_api_clients': APIClient,
             '_api_tokens': APIToken,

--- a/src/my_data/data_manipulator.py
+++ b/src/my_data/data_manipulator.py
@@ -7,7 +7,7 @@ for other DataManipulator classes.
 import logging
 from typing import Generic, Type, TypeVar
 
-from my_model import UserScopedModel
+from my_model import UserScopedResource
 from sqlalchemy.future import Engine
 
 from .context_data import ContextData
@@ -89,7 +89,7 @@ class DataManipulator(Generic[T]):
             A list with the resources.
         """
         # Check if it is a subtype of UserScopedModel
-        if not issubclass(self._database_model, UserScopedModel):
+        if not issubclass(self._database_model, UserScopedResource):
             raise WrongDataManipulatorError(  # pragma: no cover
                 f'The model "{self._database_model}" is not a UserScopedModel'
             )

--- a/src/my_data/deleters.py
+++ b/src/my_data/deleters.py
@@ -6,7 +6,7 @@ from the database. The ResourceManager uses these classes.
 
 from typing import TypeVar
 
-from my_model import MyModel, User, UserRole
+from my_model import Resource, User, UserRole
 
 from my_data.exceptions import (
     PermissionDeniedError,
@@ -15,7 +15,7 @@ from my_data.exceptions import (
 
 from .data_manipulator import DataManipulator
 
-T = TypeVar('T', bound=MyModel)
+T = TypeVar('T', bound=Resource)
 
 
 class Deleter(DataManipulator[T]):

--- a/src/my_data/resource_manager.py
+++ b/src/my_data/resource_manager.py
@@ -8,7 +8,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Generic, Type, TypeVar
 
-from my_model import MyModel
+from my_model import Resource
 from sqlalchemy.future import Engine
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -18,7 +18,7 @@ from .deleters import Deleter, UserDeleter, UserScopedDeleter
 from .retrievers import Retriever, UserRetriever, UserScopedRetriever
 from .updaters import Updater, UserScopedUpdater, UserUpdater
 
-T = TypeVar('T', bound=MyModel)
+T = TypeVar('T', bound=Resource)
 
 
 class ResourceManager(Generic[T]):

--- a/src/my_data/retrievers.py
+++ b/src/my_data/retrievers.py
@@ -6,7 +6,7 @@ data from the database. The ResourceManager uses these classes.
 
 from typing import TypeVar
 
-from my_model import MyModel, User, UserRole, UserScopedModel
+from my_model import Resource, User, UserRole, UserScopedResource
 from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.sql.expression import func
 from sqlmodel import select
@@ -15,7 +15,7 @@ from sqlmodel.sql.expression import SelectOfScalar
 from .data_manipulator import DataManipulator
 from .exceptions import BaseClassCallError, WrongDataManipulatorError
 
-T = TypeVar('T', bound=MyModel)
+T = TypeVar('T', bound=Resource)
 SelectT = TypeVar('SelectT')
 
 
@@ -167,7 +167,7 @@ class UserScopedRetriever(Retriever[T]):
         Returns:
             A list with the SQLalchmey filters.
         """
-        if not issubclass(self._database_model, UserScopedModel):
+        if not issubclass(self._database_model, UserScopedResource):
             raise WrongDataManipulatorError(
                 f'The model "{self._database_model}" is not a UserScopedModel'
             )

--- a/src/my_data/updaters.py
+++ b/src/my_data/updaters.py
@@ -6,7 +6,7 @@ in the database. The ResourceManager uses these classes.
 
 from typing import TypeVar
 
-from my_model import MyModel, User, UserRole
+from my_model import Resource, User, UserRole
 
 from my_data.exceptions import (
     PermissionDeniedError,
@@ -15,7 +15,7 @@ from my_data.exceptions import (
 
 from .data_manipulator import DataManipulator
 
-T = TypeVar('T', bound=MyModel)
+T = TypeVar('T', bound=Resource)
 
 
 class Updater(DataManipulator[T]):

--- a/src/my_model/__init__.py
+++ b/src/my_model/__init__.py
@@ -14,24 +14,24 @@ from .model import (
     APIScope,
     APIToken,
     APITokenScope,
-    MyModel,
+    Resource,
     Tag,
     TokenModel,
     User,
     UserRole,
-    UserScopedModel,
+    UserScopedResource,
     UserSetting,
 )
 
 __version__ = '1.2.3-dev'
 
 __all__ = [
-    'MyModel',
+    'Resource',
     'UserRole',
     'User',
     'APITokenScope',
     'APIScope',
-    'UserScopedModel',
+    'UserScopedResource',
     'TokenModel',
     'APIClient',
     'APIToken',

--- a/tests/fixtures_db_creation.py
+++ b/tests/fixtures_db_creation.py
@@ -33,7 +33,8 @@ def my_data() -> MyData:
     # Configure the database
     my_data = MyData()
     my_data.configure(
-        db_connection_str='sqlite:///:memory:',
+        # db_connection_str='sqlite:///:memory:',
+        db_connection_str='sqlite:////home/vscode/db.sqlite3',
         database_args={'echo': True},
         service_username='service.user',
         service_password='service_password',

--- a/tests/test_base_model.py
+++ b/tests/test_base_model.py
@@ -2,7 +2,7 @@
 # pylint: disable=redefined-outer-name
 
 import pytest
-from my_model import MyModel
+from my_model import Resource
 
 
 @pytest.mark.parametrize(
@@ -15,7 +15,7 @@ def test_base_model_get_random_token(min_value: int, max_value: int) -> None:
         min_value: the minimum password length.
         max_value: the maximum password length.
     """
-    model = MyModel()
+    model = Resource()
     random_string = model.get_random_string(
         min_length=min_value, max_length=max_value, include_punctation=True
     )


### PR DESCRIPTION
Most models are resources, so we renamed the `MyModel` class to `Resource`. We also add a `created` and `updated` field to this class and make sure these are always up-to-date with a SQLalchemy hook.

Fixes #145